### PR TITLE
Don't process EQ graph if not visible

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -78,6 +78,7 @@ CClient::CClient ( const quint16  iPortNumber,
     bEnableAudioAlerts ( false ),
     bEnableOPUS64 ( false ),
     bJitterBufferOK ( true ),
+    bOutputBandLevelsEnabled ( false ),
     bEnableIPv6 ( bNEnableIPv6 ),
     bMuteMeInPersonalMix ( bNMuteMeInPersonalMix ),
     iServerSockBufNumFrames ( DEF_NET_BUF_SIZE_NUM_BL ),
@@ -1657,6 +1658,11 @@ void CClient::ProcessAudioDataIntern ( CVector<int16_t>& vecsStereoSndCrd )
 
 void CClient::UpdateOutputBandLevels ( const CVector<int16_t>& vecsStereoSndCrd )
 {
+    if ( !bOutputBandLevelsEnabled )
+    {
+        return;
+    }
+
     constexpr float fPi                   = 3.14159265358979323846f;
     constexpr int   kOutputBands          = 8;
 

--- a/src/client.h
+++ b/src/client.h
@@ -29,6 +29,7 @@
 #include <QString>
 #include <QDateTime>
 #include <QMutex>
+#include <atomic>
 #ifdef USE_OPUS_SHARED_LIB
 #    include "opus/opus_custom.h"
 #else
@@ -339,6 +340,9 @@ public:
 
     void SetMuteOutStream ( const bool bDoMute ) { bMuteOutStream = bDoMute; }
 
+    void SetOutputBandLevelsEnabled ( const bool bEnabled ) { bOutputBandLevelsEnabled = bEnabled; }
+    bool GetOutputBandLevelsEnabled() const { return bOutputBandLevelsEnabled; }
+
     void SetRemoteChanGain ( const int iId, const float fGain, const bool bIsMyOwnFader );
     void SetRemoteChanPan ( const int iId, const float fPan );
     void OnTimerRemoteChanGainOrPan();
@@ -506,6 +510,7 @@ protected:
     QMutex MutexDriverReinit;
     QMutex MutexOutputBandLevels;
     float  afOutputBandLevels[8];
+    std::atomic<bool> bOutputBandLevelsEnabled;
 
     // server settings
     int  iServerSockBufNumFrames;

--- a/src/effectsdlg.cpp
+++ b/src/effectsdlg.cpp
@@ -278,6 +278,10 @@ void CEffectsDlg::UpdateOutputBandLevels ( const CVector<float>& vecOutLevels )
 
 void CEffectsDlg::showEvent ( QShowEvent* Event )
 {
+    if ( pClient )
+    {
+        pClient->SetOutputBandLevelsEnabled ( true );
+    }
     ApplyThemeToCustomWidgets();
 
     // Restore last used tab if valid (do this first)
@@ -292,6 +296,15 @@ void CEffectsDlg::showEvent ( QShowEvent* Event )
     UpdateEQControls();
     UpdateEQPresetSelection();
     CBaseDlg::showEvent ( Event );
+}
+
+void CEffectsDlg::hideEvent ( QHideEvent* Event )
+{
+    if ( pClient )
+    {
+        pClient->SetOutputBandLevelsEnabled ( false );
+    }
+    CBaseDlg::hideEvent ( Event );
 }
 
 void CEffectsDlg::OnUIThemeChanged() { ApplyThemeToCustomWidgets(); }

--- a/src/effectsdlg.h
+++ b/src/effectsdlg.h
@@ -34,6 +34,7 @@
 #include <QTabWidget>
 #include <QPointer>
 #include <QShowEvent>
+#include <QHideEvent>
 #include <QResizeEvent>
 #include <QEvent>
 #include <QVBoxLayout>
@@ -60,6 +61,7 @@ public:
 
 protected:
     virtual void showEvent ( QShowEvent* Event ) override;
+    virtual void hideEvent ( QHideEvent* Event ) override;
     virtual bool eventFilter ( QObject* pObj, QEvent* pEvent ) override;
 
 signals:


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

<!-- Explain what your PR does -->

CHANGELOG: <!-- Insert a short, end-user understandable sentence in past tense right here, e.g.: Client: Fixed crash when clicking the connect button too fast or SKIP if the change should not be documented in the ChangeLog -->

**Context: Fixes an issue?**

<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->

**Does this change need documentation? What needs to be documented and how?**

<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->

**Status of this Pull Request**

<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**

<!-- Does it still need more testing; ... -->

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [ ] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [ ] I tested my code and it does what I want
-  [ ] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [ ] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
